### PR TITLE
Update alphaTab import path in vite.config.ts

### DIFF
--- a/src/vite-react/package.json
+++ b/src/vite-react/package.json
@@ -10,7 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@coderline/alphatab": "^1.5.0-alpha.1396",
+    "@coderline/alphatab": "^1.8.0",
+    "@coderline/alphatab-vite": "^1.8.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/src/vite-react/vite.config.ts
+++ b/src/vite-react/vite.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
-import { alphaTab } from "@coderline/alphatab/vite";
+import { alphaTab } from "@coderline/alphatab-vite";
 
 // https://vitejs.dev/config/
 export default defineConfig({


### PR DESCRIPTION
The vite plugin is now in a separate package (haven't checked if everything else in 1.8.0 is the same).